### PR TITLE
Add email module docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ Esta es la documentación completa del frontend de FUSIONCOL. Aquí encontrarás
 - [**Drag & Drop en Workflows**](./features/drag-drop-improvements.md) - Mejoras en la funcionalidad de arrastrar y soltar
 - [**Eliminación de Elementos**](./features/delete-functionality.md) - Sistema de eliminación de nodos y conexiones
 - [**Gestión de Estado**](./features/state-management.md) - Arquitectura y patrones de estado
+- [**Módulo de Emails**](./features/email-module.md) - Configuración de cuentas y gestión de correos
 
 ### 📖 **Guías de Desarrollo**
 

--- a/docs/features/email-module.md
+++ b/docs/features/email-module.md
@@ -1,0 +1,80 @@
+# Módulo de Correos
+
+## 📋 Descripción
+
+El módulo de correos permite a los usuarios configurar su cuenta de email y gestionar mensajes desde la aplicación. Está compuesto por un servicio de API, un contexto de React para el estado global y una serie de componentes para la interfaz.
+
+## 🏗️ Arquitectura y Servicios
+
+El archivo [`src/services/emailService.ts`](../../src/services/emailService.ts) centraliza todas las llamadas a la API. Utiliza un cliente Axios con interceptor para incluir el token de autenticación de forma automática:
+
+```typescript
+const apiClient = axios.create({
+  baseURL: `${API_BASE_URL}/email`,
+});
+
+apiClient.interceptors.request.use((config) => {
+  const token = localStorage.getItem("auth_token");
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+```
+
+El servicio expone métodos como `sendEmail` que construyen un `FormData` con los campos y adjuntos del correo:
+
+```typescript
+async sendEmail(emailData: EmailCompose): Promise<any> {
+  const formData = new FormData();
+  formData.append("to", JSON.stringify(emailData.to));
+  if (emailData.cc?.length) formData.append("cc", JSON.stringify(emailData.cc));
+  if (emailData.bcc?.length) formData.append("bcc", JSON.stringify(emailData.bcc));
+  formData.append("subject", emailData.subject);
+  formData.append("content", emailData.content);
+  // ...adjuntos y cabeceras
+  const response = await apiClient.post("/send", formData, {
+    headers: { "Content-Type": "multipart/form-data" },
+  });
+  return response.data;
+}
+```
+
+## 📦 Contexto de Estado
+
+`src/contexts/EmailContext.tsx` maneja el estado global de correos. Allí se definen acciones para cargar bandejas, enviar mensajes y moverlos entre carpetas. Todas las operaciones están envueltas en `try/catch` y utilizan `toast` para notificar errores o acciones exitosas:
+
+```typescript
+const sendEmail = async (emailData: EmailCompose) => {
+  try {
+    await emailsService.emails.sendEmail(emailData);
+    dispatch({ type: "SET_COMPOSING", payload: false });
+    if (state.currentFolder === "SENT") {
+      loadEmails();
+    }
+  } catch (error) {
+    console.error("Error sending email:", error);
+    throw error; // Lo maneja el componente
+  }
+};
+```
+
+## 🖥️ Componentes Principales
+
+- **EmailClient**: interfaz principal que muestra la lista de correos y el visor.
+- **ComposeEmail** y **BaseEmailComposer**: componentes para redactar mensajes.
+- **EmailView**: permite leer un correo, responder o reenviar.
+- **EmailSetup**: asistente inicial de configuración de cuenta.
+
+Cada componente utiliza el contexto para realizar operaciones y muestra mensajes de error con `toast` cuando algo falla.
+
+## 📁 Estructura de Archivos
+
+```
+frontend/src/
+├── components/email/        # Componentes de interfaz
+├── contexts/EmailContext.tsx
+└── services/emailService.ts
+```
+
+Con esta estructura se logra una separación clara entre lógica de negocio, estado global y componentes de presentación.


### PR DESCRIPTION
## Summary
- document email module architecture and components
- link email documentation from main docs README

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684035d22c1083268649fd42873150f4