### PR TITLE
Use current user ID for conversation messages

### DIFF
--- a/src/services/conversationService.ts
+++ b/src/services/conversationService.ts
@@ -1,4 +1,5 @@
 import { apiService } from "../config/apiConfig";
+import { authService } from "../config/authConfig";
 
 /**
  * Get all conversations
@@ -121,8 +122,12 @@ const sendMessage = async (payload: any) => {
     if (!conversationId) throw new Error("conversationId requerido");
     if (!to) throw new Error("destinatario (to) requerido");
 
+    const currentUser = authService.getUser();
+    const userId = currentUser?.id || currentUser?._id;
+
     const body = {
-      from: "system", // asegurar valor no vacío para backends que lo requieren
+      // Fallback explícito a "system" si no se encuentra un identificador de usuario
+      from: userId ?? "system",
       to,
       message: messageText,
       mediaUrl,


### PR DESCRIPTION
## Summary
- include auth service in conversation service
- send messages from the current user's id with explicit fallback

## Testing
- `npm run lint` *(fails: Unexpected any errors)*
- `npm test` *(fails: Missing script: "test")*
- `npx vitest run` *(fails: Cannot find dependency 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_68a4c482d814832f97ddc5560bd52f68