### PR TITLE
Require socket URL env and document deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,8 @@
 VITE_API_BASE_URL=http://localhost:3001/api/v1
 VITE_API_TIMEOUT=10000
 VITE_API_DIAN=http://148.113.175.139/api
+
+# WebSocket server URL (required)
 VITE_SOCKET_URL=https://fusioncrmapiv3-production.up.railway.app
 # VITE_SOCKET_URL=http://localhost:3001
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,7 @@ Esta es la documentación completa del frontend de FUSIONCOL. Aquí encontrarás
 - [**Gestión de Estado**](./guides/state-management.md) - Patrones y arquitectura de estado
 - [**Testing**](./guides/testing.md) - Estrategias y herramientas de testing
 - [**Convenciones de Código**](./guides/code-conventions.md) - Estándares de código y estilo
+- [**Deployment**](./guides/deployment.md) - Variables de entorno y despliegue
 
 ### 🔌 **API y Servicios**
 
@@ -192,12 +193,12 @@ frontend/
 - [x] Guías de desarrollo
 - [x] Documentación de funcionalidades core
 - [x] Estructura y organización
+- [x] Documentación de deployment
 
 ### 🚧 En Progreso
 
 - [ ] Documentación de API services
 - [ ] Guías de testing específicas
-- [ ] Documentación de deployment
 
 ### 📋 Pendiente
 

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -1,0 +1,10 @@
+# Deployment
+
+## Environment Variables
+
+The application requires the following environment variables to run:
+
+- `VITE_API_BASE_URL`: Base URL for the REST API.
+- `VITE_SOCKET_URL`: WebSocket server URL. This variable is required and has no default; builds will fail if it is missing.
+
+Copy `.env.example` to your environment file and provide values for these variables before building or deploying the app.

--- a/src/services/socketService.ts
+++ b/src/services/socketService.ts
@@ -1,8 +1,11 @@
 import { io } from "socket.io-client";
 import { authService } from "../config/authConfig";
 
-// const SOCKET_URL = "http://localhost:3001"; // Temporalmente forzado a local
-const SOCKET_URL = import.meta.env.VITE_SOCKET_URL || "http://localhost:3001";
+const SOCKET_URL = import.meta.env.VITE_SOCKET_URL;
+
+if (!SOCKET_URL) {
+  throw new Error("VITE_SOCKET_URL is not defined");
+}
 
 export const socket = io(SOCKET_URL, {
   autoConnect: true,


### PR DESCRIPTION
## Summary
- enforce VITE_SOCKET_URL presence in socketService
- document WebSocket env var in .env.example and new deployment guide

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4c487a614832f9cc57cc924a35f24